### PR TITLE
(BOLT-688) Expand search for facter task

### DIFF
--- a/tasks/bash.sh
+++ b/tasks/bash.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 # Delegate to facter if available
+export PATH="$PATH:/opt/puppetlabs/bin"
 command -v facter > /dev/null 2>&1 && exec facter -p --json --show-legacy
 
 minor () {

--- a/tasks/ruby.rb
+++ b/tasks/ruby.rb
@@ -2,16 +2,38 @@
 # frozen_string_literal: true
 
 def facter_executable
-  if ENV.key? 'Path'
-    ENV['Path'].split(';').each do |p|
-      if p =~ /Puppet\\bin\\?$/
-        return File.join(p, 'facter')
+  if Gem.win_platform?
+    require 'win32/registry'
+    installed_dir =
+      begin
+        Win32::Registry::HKEY_LOCAL_MACHINE.open('SOFTWARE\Puppet Labs\Puppet') do |reg|
+          # rubocop:disable Style/RescueModifier
+          # Rescue missing key
+          dir = reg['RememberedInstallDir64'] rescue ''
+          # Both keys may exist, make sure the dir exists
+          break dir if File.exist?(dir)
+
+          # Rescue missing key
+          reg['RememberedInstallDir'] rescue ''
+          # rubocop:enable Style/RescueModifier
+        end
+      rescue Win32::Registry::Error
+        # Rescue missing registry path
+        ''
       end
-    end
-    'C:\Program Files\Puppet Labs\Puppet\bin\facter'
+
+    facter =
+      if installed_dir.empty?
+        ''
+      else
+        File.join(installed_dir, 'bin', 'facter')
+      end
   else
-    '/opt/puppetlabs/puppet/bin/facter'
+    facter = '/opt/puppetlabs/puppet/bin/facter'
   end
+
+  # Fall back to PATH lookup if puppet-agent isn't installed
+  File.exist?(facter) ? facter : 'facter'
 end
 
 # Delegate to facter


### PR DESCRIPTION
Extend bash implementation by adding default location of facter to the path.
Extend ruby implementation to handle the case where puppet-agent is not installed in default location.