### PR TITLE
(BOLT-915) Make bash.sh facts implementation shareable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,14 @@ matrix:
       bundler_args:
       dist: trusty
       env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_set=docker/centos-7
-      script: bundle exec rake beaker
+      script: bundle exec rake task_acceptance
       services: docker
       sudo: required
     -
       bundler_args:
       dist: trusty
       env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_set=docker/ubuntu-14.04
-      script: bundle exec rake beaker
+      script: bundle exec rake task_acceptance
       services: docker
       sudo: required
     -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Change Log
+## 0.4.0
+### Added
+- The `bash.sh` implementation can accept the positional arguments `platform` or `release` to support the `puppet_agent::install` task. 
 
 ## 0.3.1
 ### Fixed

--- a/Gemfile
+++ b/Gemfile
@@ -70,7 +70,7 @@ gems['facter'] = location_for(facter_version) if facter_version
 gems['hiera'] = location_for(hiera_version) if hiera_version
 gems['puppet'] = location_for(puppet_version) if puppet_version
 # gem 'bolt', '~> 1.0.0', require: false
-gem 'bolt', git: "https://github.com/puppetlabs/bolt.git", require: false
+gem 'bolt', git: "https://github.com/puppetlabs/bolt.git", ref: "60eabc621eeaa12a157170aa0e99b29ed5aca4cb", require: false
 gem 'beaker-task_helper', '~> 1.5.2', require: false
 
 if Gem.win_platform? && puppet_version =~ %r{^(file:///|git://)}

--- a/Gemfile
+++ b/Gemfile
@@ -57,7 +57,7 @@ end
 
 # Temporarily pin to Puppet 6. 6.0.1 introduces a change in behavior that
 # will require a newer release of Bolt for bolt_spec to work.
-puppet_version = ENV['PUPPET_GEM_VERSION'] || '= 6.0.0'
+puppet_version = ENV['PUPPET_GEM_VERSION'] || '= 6.0.1'
 facter_version = ENV['FACTER_GEM_VERSION']
 hiera_version = ENV['HIERA_GEM_VERSION']
 
@@ -69,7 +69,9 @@ gems = {}
 gems['facter'] = location_for(facter_version) if facter_version
 gems['hiera'] = location_for(hiera_version) if hiera_version
 gems['puppet'] = location_for(puppet_version) if puppet_version
-gem 'bolt', '~> 0.23.0'
+# gem 'bolt', '~> 1.0.0', require: false
+gem 'bolt', git: "https://github.com/puppetlabs/bolt.git", require: false
+gem 'beaker-task_helper', '~> 1.5.2', require: false
 
 if Gem.win_platform? && puppet_version =~ %r{^(file:///|git://)}
   # If we're using a Puppet gem on Windows which handles its own win32-xxx gem

--- a/README.md
+++ b/README.md
@@ -19,6 +19,29 @@ The provided tasks:
 * `facts::powershell` - powershell implementation of fact gathering, used by the `facts` task.
 * `facts::ruby` - ruby implementation of fact gathering, used by the `facts` task.
 
+`puppet_agent` module support:
+The `puppet_agent::install_shell` task uses the `bash.sh` implementation code to gather facts. When `bash.sh` is invoked with the positional argument `platform` or `release` *only* the requested fact is returned. 
+
+Example
+```
+root@y77tzpv6qxnx5at:~# ./bash.sh 
+{
+  "os": {
+    "name": "Ubuntu",
+    "release": {
+      "full": "16.04",
+      "major": "16",
+      "minor": "04"
+    },
+    "family": "Debian"
+  }
+}
+root@y77tzpv6qxnx5at:~# ./bash.sh "release"
+16.04
+root@y77tzpv6qxnx5at:~# ./bash.sh "platform"
+Ubuntu
+```
+
 ## Requirements
 
 This module is compatible with the version of Puppet Bolt it ships with.

--- a/Rakefile
+++ b/Rakefile
@@ -6,3 +6,7 @@ require 'puppet_blacksmith/rake_tasks' if Bundler.rubygems.find_name('puppet-bla
 require 'puppet-lint/tasks/puppet-lint'
 
 PuppetLint.configuration.send('disable_relative')
+
+task :task_acceptance => [:spec_prep, :beaker] do
+  # nothing to do
+end

--- a/spec/.fixtures.yml
+++ b/spec/.fixtures.yml
@@ -1,0 +1,3 @@
+fixtures:
+  symlinks:
+    facts: "#{File.absolute_path(File.join(source_dir, '..'))}"

--- a/spec/acceptance/init_spec.rb
+++ b/spec/acceptance/init_spec.rb
@@ -1,16 +1,49 @@
 # frozen_string_literal: true
 
 require 'spec_helper_acceptance'
+require 'beaker-task_helper/inventory'
+require 'bolt_spec/run'
 
 describe 'facts task' do
+  include Beaker::TaskHelper::Inventory
+  include BoltSpec::Run
+
+  def module_path
+    RSpec.configuration.module_path
+  end
+
+  def config
+    { 'modulepath' => module_path }
+  end
+
+  def inventory
+    hosts_to_inventory
+  end
+
   operating_system_fact = fact('operatingsystem')
   os_family_fact = fact('osfamily')
+  platform = fact('os.name')
+  release = fact('os.release.full')
 
   describe 'puppet facts' do
+    let(:script) { File.join(__dir__, '..', '..', 'tasks', 'bash.sh') }
+
+    it 'bash implementation returns platform' do
+      result = run_script(script, 'default', ['platform'], inventory: inventory)
+      expect(result[0]['status']).to eq('success')
+      expect(result[0]['result']['stdout']).to match(/#{platform}/)
+    end
+
+    it 'bash implementation returns release' do
+      result = run_script(script, 'default', ['release'], inventory: inventory)
+      expect(result[0]['status']).to eq('success')
+      expect(result[0]['result']['stdout']).to match(/#{release}/)
+    end
+
     it 'includes legacy and structured facts' do
-      result = run_task(task_name: 'facts', format: 'json')
-      expect(result['status']).to eq('success')
-      facts = result['result']
+      result = run_task('facts', 'default', config: config, inventory: inventory)
+      expect(result[0]['status']).to eq('success')
+      facts = result[0]['result']
       expect(facts).to include('osfamily', 'operatingsystem', 'os')
 
       expect(facts['osfamily']).to eq(os_family_fact)

--- a/spec/plans/init_spec.rb
+++ b/spec/plans/init_spec.rb
@@ -68,7 +68,7 @@ describe 'facts' do
     end
 
     it 'does not mask errors' do
-     expect_task('facts').always_return(err_output)
+      expect_task('facts').always_return(err_output)
       inventory.expects(:add_facts).never
 
       expect(run_plan('facts', 'nodes' => [node]).value.msg).to eq("Plan aborted: run_task 'facts' failed on 1 nodes")

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -4,22 +4,24 @@ require 'puppet'
 require 'beaker-rspec'
 require 'beaker/puppet_install_helper'
 require 'beaker/module_install_helper'
-require 'beaker-task_helper'
+require 'puppetlabs_spec_helper/module_spec_helper'
 
 run_puppet_install_helper
-install_ca_certs unless pe_install?
-install_bolt_on(hosts, '0.21.3') unless pe_install?
+install_ca_certs
 install_module_on(hosts)
 install_module_dependencies_on(hosts)
 
+base_dir = File.dirname(File.expand_path(__FILE__))
+
 UNSUPPORTED_PLATFORMS = %w[Solaris AIX].freeze
+
+base_dir = File.dirname(File.expand_path(__FILE__))
 
 RSpec.configure do |c|
   # Readable test descriptions
   c.formatter = :documentation
 
-  # Configure all nodes in nodeset
-  c.before :suite do
-    run_puppet_access_login(user: 'admin') if pe_install?
-  end
+  # should we just use rspec_puppet
+  c.add_setting :module_path
+  c.module_path = File.join(base_dir, 'fixtures', 'modules')
 end


### PR DESCRIPTION
The puppetlabs-puppet_agent install_shell.sh implementation relies on determining target platform and version. With the introduction of multi-file task support this commit facilitates the use of the facts::bash implementation. The bash.sh implementation can now accept a positional argument that can be set to `platform` or `version`. This results in the requested data being printed to stdout instead of the full JSON report that would be printed without the positional argument.