### PR TITLE
(BOLT-915) Publish 0.4.1 to Forge

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,0 +1,3 @@
+fixtures:
+  symlinks:
+    facts: "#{source_dir}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ language: ruby
 cache: bundler
 rvm:
 - 2.4
-bundler_args: --without system_tests
+env:
+  global:
+    - GEM_BOLT=true
 script:
   - 'bundle exec rake $CHECK'
 matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Change Log
+## 0.4.1
+### Changed
+- Only install bolt for testing when GEM_BOLT environment variable is set.
+
 ## 0.4.0
 ### Added
 - The `bash.sh` implementation can accept the positional arguments `platform` or `release` to support the `puppet_agent::install` task. 

--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,11 @@ group :system_tests do
   gem "beaker-pe",
       require: false
   gem "beaker-rspec"
+  
+  if ENV['GEM_BOLT']
+    gem 'bolt', git: "https://github.com/puppetlabs/bolt.git", ref: "60eabc621eeaa12a157170aa0e99b29ed5aca4cb", require: false
+    gem 'beaker-task_helper', '~> 1.5.2', require: false
+  end
 end
 
 # Temporarily pin to Puppet 6. 6.0.1 introduces a change in behavior that
@@ -69,9 +74,6 @@ gems = {}
 gems['facter'] = location_for(facter_version) if facter_version
 gems['hiera'] = location_for(hiera_version) if hiera_version
 gems['puppet'] = location_for(puppet_version) if puppet_version
-# gem 'bolt', '~> 1.0.0', require: false
-gem 'bolt', git: "https://github.com/puppetlabs/bolt.git", ref: "60eabc621eeaa12a157170aa0e99b29ed5aca4cb", require: false
-gem 'beaker-task_helper', '~> 1.5.2', require: false
 
 if Gem.win_platform? && puppet_version =~ %r{^(file:///|git://)}
   # If we're using a Puppet gem on Windows which handles its own win32-xxx gem

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-facts",
-  "version": "0.3.1",
+  "version": "0.4.1",
   "author": "puppet",
   "summary": "Tasks that inspect the value of system facts",
   "license": "Apache-2.0",


### PR DESCRIPTION
Only require Bolt when the GEM_BOLT environment variable is set to avoid conflicts with puppet5 in the publish to Forge Jenkins job. 