### PR TITLE
(BOLT-997) Clean bash implementation for RedHat

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,7 @@ group :system_tests do
   gem "beaker-rspec"
   
   if ENV['GEM_BOLT']
-    gem 'bolt', git: "https://github.com/puppetlabs/bolt.git", ref: "60eabc621eeaa12a157170aa0e99b29ed5aca4cb", require: false
+    gem 'bolt', '~> 1.4', require: false
     gem 'beaker-task_helper', '~> 1.5.2', require: false
   end
 end

--- a/spec/acceptance/linux_spec.rb
+++ b/spec/acceptance/linux_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'spec_helper_acceptance'
+require 'beaker-task_helper/inventory'
+require 'bolt_spec/run'
+
+describe 'facts task' do
+  include Beaker::TaskHelper::Inventory
+  include BoltSpec::Run
+
+  def module_path
+    RSpec.configuration.module_path
+  end
+
+  def config
+    { 'modulepath' => module_path }
+  end
+
+  def inventory
+    hosts_to_inventory
+  end
+
+  os_family_fact = fact('osfamily')
+  platform = fact('os.name') == 'OracleLinux' ? 'RedHat' : fact('os.name')
+  release = fact('os.release.full')
+
+  describe 'bash facts implementation', unless: fact_on(default, 'osfamily') == 'windows' do
+    let(:script) { File.join(__dir__, '..', '..', 'tasks', 'bash.sh') }
+
+    it 'returns platform when invoked with platform parameter' do
+      result = run_script(script, 'default', ['platform'], inventory: inventory)
+      expect(result[0]['status']).to eq('success')
+      expect(result[0]['result']['stdout']).to match(/#{platform}/)
+    end
+
+    it 'returns release when invoked with release parameter' do
+      result = run_script(script, 'default', ['release'], inventory: inventory)
+      expect(result[0]['status']).to eq('success')
+      expect(release).to match(/#{result[0]['result']['stdout'].strip}/)
+    end
+
+    it 'returns facts json' do
+      result = run_task('facts::bash', 'default', config: config, inventory: inventory)
+      facts = result[0]['result']
+      expect(facts).to include('os')
+      expect(facts['os']). to include('family', 'name', 'release')
+      expect(facts['os']['family']).to match(/#{os_family_fact}/)
+      expect(facts['os']['name']).to match(/#{platform}/)
+      expect(release).to match(/#{facts['os']['release']['full']}/)
+    end
+  end
+end

--- a/spec/acceptance/windows_spec.rb
+++ b/spec/acceptance/windows_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'spec_helper_acceptance'
+require 'beaker-task_helper/inventory'
+require 'bolt_spec/run'
+
+describe 'facts task', if: fact('osfamily') == 'windows' do
+  include Beaker::TaskHelper::Inventory
+  include BoltSpec::Run
+
+  def module_path
+    RSpec.configuration.module_path
+  end
+
+  def config
+    { 'modulepath' => module_path }
+  end
+
+  def inventory
+    hosts_to_inventory
+  end
+
+  os_family_fact = fact('osfamily')
+  platform = fact('os.name')
+  release = fact('os.release.full')
+
+  describe 'bash facts implementation', unless: fact_on(default, 'os.release.full') == '2008 R2' do
+    it 'returns facts json' do
+      result = run_task('facts::powershell', 'default', config: config, inventory: inventory)
+      facts = result[0]['result']
+      expect(facts).to include('os')
+      expect(facts['os']). to include('family', 'name', 'release')
+      expect(facts['os']['family']).to match(/#{os_family_fact}/)
+      expect(facts['os']['name']).to match(/#{platform}/)
+      expect(release).to match(/#{facts['os']['release']['full']}/)
+    end
+  end
+end

--- a/tasks/bash.sh
+++ b/tasks/bash.sh
@@ -14,6 +14,8 @@ if [ -f /etc/redhat-release ]; then
         name=CentOS
     elif egrep -iq 'Fedora release' /etc/redhat-release; then
         name=Fedora
+    elif egrep -iq "(.*red)(.*hat)" /etc/redhat-release; then
+        name=RedHat
     fi
     release=$(sed -r -e 's/^.* release ([0-9]+(\.[0-9]+)?).*$/\1/' \
                   /etc/redhat-release)
@@ -24,6 +26,9 @@ if [ -z "${name}" ]; then
     if [ -n "$LSB_RELEASE" ]; then
         if [ -z "$name" ]; then
             name=$($LSB_RELEASE -i | sed -re 's/^.*:[ \t]*//')
+            if echo "${name}" | egrep -iq "(.*red)(.*hat)"; then
+                name="RedHat"
+            fi
         fi
         release=$($LSB_RELEASE -r | sed -re 's/^.*:[ \t]*//')
     fi

--- a/tasks/ruby.rb
+++ b/tasks/ruby.rb
@@ -1,5 +1,6 @@
-#!/usr/bin/env ruby
+#!/opt/puppetlabs/puppet/bin/ruby
 # frozen_string_literal: true
+require 'open3'
 
 def facter_executable
   if Gem.win_platform?


### PR DESCRIPTION
When `lsb_release` is used to find platform name in the bash implementation for some red-hat versions (example redhat-5-x86_64) the OS name fact reports `RedHatEnterpriseServer`. This commit changes shortens the output to `RedHat` as the puppet_agent::install task expects.

When a target is missing both `lsb_release` and `os-release` pick up the name and version from `redhat-release`.