### PR TITLE
(BOLT-1057) Pass required args to run_task

### DIFF
--- a/spec/acceptance/init_spec.rb
+++ b/spec/acceptance/init_spec.rb
@@ -27,7 +27,7 @@ describe 'facts task', unless: fact_on(default, 'os.release.full') == '2008 R2' 
 
   describe 'puppet facts' do
     it 'includes legacy and structured facts' do
-      result = run_task('facts', 'default', config: config, inventory: inventory)
+      result = run_task('facts', 'default', {}, config: config, inventory: inventory)
       expect(result[0]['status']).to eq('success')
       facts = result[0]['result']
 

--- a/spec/acceptance/linux_spec.rb
+++ b/spec/acceptance/linux_spec.rb
@@ -40,7 +40,7 @@ describe 'facts task' do
     end
 
     it 'returns facts json' do
-      result = run_task('facts::bash', 'default', config: config, inventory: inventory)
+      result = run_task('facts::bash', 'default', {}, config: config, inventory: inventory)
       facts = result[0]['result']
       expect(facts).to include('os')
       expect(facts['os']). to include('family', 'name', 'release')

--- a/spec/acceptance/windows_spec.rb
+++ b/spec/acceptance/windows_spec.rb
@@ -26,7 +26,7 @@ describe 'facts task', if: fact('osfamily') == 'windows' do
 
   describe 'bash facts implementation', unless: fact_on(default, 'os.release.full') == '2008 R2' do
     it 'returns facts json' do
-      result = run_task('facts::powershell', 'default', config: config, inventory: inventory)
+      result = run_task('facts::powershell', 'default', {}, config: config, inventory: inventory)
       facts = result[0]['result']
       expect(facts).to include('os')
       expect(facts['os']). to include('family', 'name', 'release')


### PR DESCRIPTION
Previously, the tests were omitting the `params` argument to `run_task`.
In newer versions of BoltSpec, that parameter is going to be required,
so now we always pass it.