### PR TITLE
(MODULES-8717) Move shared dependency to spec_helper

### DIFF
--- a/spec/acceptance/init_spec.rb
+++ b/spec/acceptance/init_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper_acceptance'
-require 'beaker-task_helper/inventory'
-require 'bolt_spec/run'
 
 describe 'facts task', unless: fact_on(default, 'os.release.full') == '2008 R2' do
   include Beaker::TaskHelper::Inventory

--- a/spec/acceptance/linux_spec.rb
+++ b/spec/acceptance/linux_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper_acceptance'
-require 'beaker-task_helper/inventory'
-require 'bolt_spec/run'
 
 describe 'facts task' do
   include Beaker::TaskHelper::Inventory

--- a/spec/acceptance/windows_spec.rb
+++ b/spec/acceptance/windows_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper_acceptance'
-require 'beaker-task_helper/inventory'
-require 'bolt_spec/run'
 
 describe 'facts task', if: fact('osfamily') == 'windows' do
   include Beaker::TaskHelper::Inventory

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'beaker-task_helper/inventory'
+require 'bolt_spec/run'
 require 'puppet'
 require 'beaker-rspec'
 require 'beaker/puppet_install_helper'


### PR DESCRIPTION
All of the acceptance tests for the bolt task/plan content is shared by tests. Move to spec_helper_acceptance.