### PR TITLE
(MODULES-8750) Improve facts bash task implementation

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -41,7 +41,7 @@ Gemfile:
           - mingw
           - x64_mingw
       - gem: bolt
-        version: '~> 1.3'
+        version: '~> 1.15'
         condition: ENV['GEM_BOLT']
       - gem: beaker-task_helper
         version: '~> 1.5.2'

--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ end
 group :system_tests do
   gem "puppet-module-posix-system-r#{minor_version}", require: false, platforms: [:ruby]
   gem "puppet-module-win-system-r#{minor_version}",   require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "bolt", '~> 1.3',                               require: false if ENV['GEM_BOLT']
+  gem "bolt", '~> 1.15',                               require: false if ENV['GEM_BOLT']
   gem "beaker-task_helper", '~> 1.5.2',               require: false if ENV['GEM_BOLT']
 end
 

--- a/spec/acceptance/init_spec.rb
+++ b/spec/acceptance/init_spec.rb
@@ -8,15 +8,11 @@ describe 'facts task', unless: fact_on(default, 'os.release.full') == '2008 R2' 
   include Beaker::TaskHelper::Inventory
   include BoltSpec::Run
 
-  def module_path
-    RSpec.configuration.module_path
+  def bolt_config
+    { 'modulepath' => RSpec.configuration.module_path }
   end
 
-  def config
-    { 'modulepath' => module_path }
-  end
-
-  def inventory
+  def bolt_inventory
     hosts_to_inventory.merge('features' => ['puppet-agent'])
   end
 
@@ -27,7 +23,7 @@ describe 'facts task', unless: fact_on(default, 'os.release.full') == '2008 R2' 
 
   describe 'puppet facts' do
     it 'includes legacy and structured facts' do
-      result = run_task('facts', 'default', {}, config: config, inventory: inventory)
+      result = run_task('facts', 'default', {})
       expect(result[0]['status']).to eq('success')
       facts = result[0]['result']
 

--- a/spec/acceptance/linux_spec.rb
+++ b/spec/acceptance/linux_spec.rb
@@ -8,15 +8,11 @@ describe 'facts task' do
   include Beaker::TaskHelper::Inventory
   include BoltSpec::Run
 
-  def module_path
-    RSpec.configuration.module_path
+  def bolt_config
+    { 'modulepath' => RSpec.configuration.module_path }
   end
 
-  def config
-    { 'modulepath' => module_path }
-  end
-
-  def inventory
+  def bolt_inventory
     hosts_to_inventory
   end
 
@@ -28,19 +24,19 @@ describe 'facts task' do
     let(:script) { File.join(__dir__, '..', '..', 'tasks', 'bash.sh') }
 
     it 'returns platform when invoked with platform parameter' do
-      result = run_script(script, 'default', ['platform'], inventory: inventory)
+      result = run_script(script, 'default', ['platform'])
       expect(result[0]['status']).to eq('success')
       expect(result[0]['result']['stdout']).to match(/#{platform}/)
     end
 
     it 'returns release when invoked with release parameter' do
-      result = run_script(script, 'default', ['release'], inventory: inventory)
+      result = run_script(script, 'default', ['release'])
       expect(result[0]['status']).to eq('success')
       expect(release).to match(/#{result[0]['result']['stdout'].strip}/)
     end
 
     it 'returns facts json' do
-      result = run_task('facts::bash', 'default', {}, config: config, inventory: inventory)
+      result = run_task('facts::bash', 'default', {})
       facts = result[0]['result']
       expect(facts).to include('os')
       expect(facts['os']). to include('family', 'name', 'release')

--- a/spec/acceptance/windows_spec.rb
+++ b/spec/acceptance/windows_spec.rb
@@ -8,15 +8,11 @@ describe 'facts task', if: fact('osfamily') == 'windows' do
   include Beaker::TaskHelper::Inventory
   include BoltSpec::Run
 
-  def module_path
-    RSpec.configuration.module_path
+  def bolt_config
+    { 'modulepath' => RSpec.configuration.module_path }
   end
 
-  def config
-    { 'modulepath' => module_path }
-  end
-
-  def inventory
+  def bolt_inventory
     hosts_to_inventory
   end
 
@@ -26,7 +22,7 @@ describe 'facts task', if: fact('osfamily') == 'windows' do
 
   describe 'bash facts implementation', unless: fact_on(default, 'os.release.full') == '2008 R2' do
     it 'returns facts json' do
-      result = run_task('facts::powershell', 'default', {}, config: config, inventory: inventory)
+      result = run_task('facts::powershell', 'default', {})
       facts = result[0]['result']
       expect(facts).to include('os')
       expect(facts['os']). to include('family', 'name', 'release')

--- a/tasks/bash.sh
+++ b/tasks/bash.sh
@@ -39,7 +39,7 @@ if [ -z "${name}" ]; then
     if [ -e /etc/os-release ]; then
         name=$(grep "^NAME" /etc/os-release | cut -d'=' -f2 | sed "s/\"//g")
         release=$(grep "^VERSION_ID" /etc/os-release | cut -d'=' -f2 | sed "s/\"//g")
-    elif [-e /usr/lib/os-release ]; then
+    elif [ -e /usr/lib/os-release ]; then
         name=$(grep "^NAME" /usr/lib/os-release | cut -d'=' -f2 | sed "s/\"//g")
         release=$(grep "^VERSION_ID" /usr/lib/os-release | cut -d'=' -f2 | sed "s/\"//g")
     fi

--- a/tasks/powershell.ps1
+++ b/tasks/powershell.ps1
@@ -33,7 +33,11 @@ if ([System.Environment]::OSVersion.Platform -gt 2) {
     }
 
     $release = switch($version){
-        '10.0'{ if ($consumerrel) { '10' } else { '2016' } }
+        '10.0'{ 
+            if ($consumerrel) { '10' } else {
+                if ($os.BuildNumber -ge 17763) { '2019' } else {'2016' }
+            }
+        }
         '6.3' { if ($consumerrel) { '8.1' } else { '2012 R2' } }
         '6.2' { if ($consumerrel) { '8' } else { '2012' } }
         '6.1' { if ($consumerrel) { '7' } else { '2008 R2' } }


### PR DESCRIPTION
As pointed out in https://github.com/puppetlabs/puppetlabs-facts/issues/24 there is a typo in the bash facts implementation that can result in failure when reading `/usr/lib/os-release`. This commit fixes the typo.