### PR TITLE
(FM-7967) Ensure bash script EOL is LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+*.rb eol=lf
+*.erb eol=lf
+*.pp eol=lf
+*.sh eol=lf
+*.epp eol=lf


### PR DESCRIPTION
Prior to this commit there was no gitattributes file so all files will, by default, check out on Windows as CRLF. This causes problems when executing the tasks against *nix nodes, particularly shell script tasks, as the carriage return is included in the copied file.

This commit adds a gitattribute file which normalizes files which should not have CRLF to LF. This set of file types to have LF ensured was taken from the provision and scheduled_task modules, both of which use this same list. The puppet_agent module uses a similar though smaller list.