### PR TITLE
(MODULES-9530) Mirror C++ facter structure for codename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.6.0
+### Added
+- The `bash.sh` implementation can now provide distro code-name when possible.
+
 ## 0.5.1
 ### Fixed
 - Powershell implementation now correctly detects windows server 2019 and handles incompatible powershell version gracefully.

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-facts",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "author": "puppet",
   "summary": "Tasks that inspect the value of system facts",
   "license": "Apache-2.0",

--- a/spec/acceptance/linux_spec.rb
+++ b/spec/acceptance/linux_spec.rb
@@ -36,8 +36,9 @@ describe 'facts task' do
     it 'returns facts json' do
       result = run_task('facts::bash', 'default', {})
       facts = result[0]['result']
+      expect(facts['os']['distro']).to include('codename')
       expect(facts).to include('os')
-      expect(facts['os']). to include('family', 'name', 'release')
+      expect(facts['os']).to include('family', 'name', 'release')
       expect(facts['os']['family']).to match(/#{os_family_fact}/)
       expect(facts['os']['name']).to match(/#{platform}/)
       expect(release).to match(/#{facts['os']['release']['full']}/)

--- a/tasks/bash.sh
+++ b/tasks/bash.sh
@@ -165,13 +165,15 @@ success "$(cat <<EOF
 {
   "os": {
     "name": "$ID",
-    "codename": "$VERSION_CODENAME",
+    "distro": {
+      "codename": "$VERSION_CODENAME"
+    },
     "release": {
       "full": "$full",
       "major": "$major",
       "minor": "$minor"
     },
-    "family": "${family}"
+    "family": "$family"
   }
 }
 EOF


### PR DESCRIPTION
Previously the codename was at the top level as `os` for the bash implementation. This commit pushes it down under `distro` to mirrow what the C++ facter implementation does.