### PR TITLE
(GH-1376) Change $nodes param to $targets in plans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 
 ## 0.6.1
+### Changed
+- The `$nodes` parameter was changed to `$targets` in both the `facts` and `facts::info` plans.
+
 ### Fixed
 - Bash implementation now correctly detects platform information when using bash 3.1 and 3.2.
 

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@
 
 ## Description
 
-This module provides a collection of facts tasks and plans all of which retrieve facts from the specified nodes but each of them processes the retrieved facts differently. The provided plans are:
-* `facts` - retrieves the facts and then stores them in the inventory, returns a result set wrapping result objects for each specified node which in turn wrap the retrieved facts
-* `facts::info` - retrieves the facts and returns information about each node's OS compiled from the `os` fact value retrieved from that node
+This module provides a collection of facts tasks and plans all of which retrieve facts from the specified targets but each of them processes the retrieved facts differently. The provided plans are:
+* `facts` - retrieves the facts and then stores them in the inventory, returns a result set wrapping result objects for each specified target which in turn wrap the retrieved facts
+* `facts::info` - retrieves the facts and returns information about each target's OS compiled from the `os` fact value retrieved from that target
 
 The provided tasks:
-* `facts` - retrieves the facts and without further processing returns a result set wrapping result objects for each specified node which in turn wrap the retrieved facts (this task is used by the above plans). This task relies on cross-platform task support; if unavailable, the individual implementations can be used instead.
+* `facts` - retrieves the facts and without further processing returns a result set wrapping result objects for each specified target which in turn wrap the retrieved facts (this task is used by the above plans). This task relies on cross-platform task support; if unavailable, the individual implementations can be used instead.
 * `facts::bash` - bash implementation of fact gathering, used by the `facts` task.
 * `facts::powershell` - powershell implementation of fact gathering, used by the `facts` task.
 * `facts::ruby` - ruby implementation of fact gathering, used by the `facts` task.
@@ -51,14 +51,14 @@ This module is compatible with the version of Puppet Bolt it ships with.
 To run the facts plan run
 
 ```
-bolt plan run facts --nodes node1.example.com,node2.example.com
+bolt plan run facts --targets target1.example.com,target2.example.com
 ```
 
 ### Parameters
 
 All plans have only one parameter:
 
-* **nodes** - The nodes to retrieve the facts from.
+* `targets` - The targets to retrieve the facts from.
 
 ## Reference
 

--- a/plans/info.pp
+++ b/plans/info.pp
@@ -1,16 +1,16 @@
-# A plan that prints basic OS information for the specified nodes. It first
-# runs the facts task to retrieve facts from the nodes, then compiles the
-# desired OS information from the os fact value of each nodes.
+# A plan that prints basic OS information for the specified targets. It first
+# runs the facts task to retrieve facts from the targets, then compiles the
+# desired OS information from the os fact value of each targets.
 #
-# The $nodes parameter is a list of the nodes for which to print the OS
+# The $targets parameter is a list of the targets for which to print the OS
 # information. This plan primarily provides readable formatting, and ignores
-# nodes that error.
-plan facts::info(TargetSpec $nodes) {
-  return run_task('facts', $nodes, '_catch_errors' => true).reduce([]) |$info, $r| {
+# targets that error.
+plan facts::info(TargetSpec $targets) {
+  return run_task('facts', $targets, '_catch_errors' => true).reduce([]) |$info, $r| {
     if ($r.ok) {
       $info + "${r.target.name}: ${r[os][name]} ${r[os][release][full]} (${r[os][family]})"
     } else {
-      $info # don't include any info for nodes which failed
+      $info # don't include any info for targets which failed
     }
   }
 }

--- a/plans/init.pp
+++ b/plans/init.pp
@@ -1,9 +1,9 @@
 # A plan that retrieves facts and stores in the inventory for the
-# specified nodes.
+# specified targets.
 #
-# The $nodes parameter is a list of nodes to retrieve the facts for.
-plan facts(TargetSpec $nodes) {
-  $result_set = run_task('facts', $nodes)
+# The $targets parameter is a list of targets to retrieve the facts for.
+plan facts(TargetSpec $targets) {
+  $result_set = run_task('facts', $targets)
 
   $result_set.each |$result| {
     add_facts($result.target, $result.value)

--- a/spec/plans/info_spec.rb
+++ b/spec/plans/info_spec.rb
@@ -7,91 +7,91 @@ describe 'facts::info' do
   include BoltSpec::Plans
 
   context 'an ssh target' do
-    let(:node) { 'ssh://host' }
+    let(:target) { 'ssh://host' }
 
     it 'contains OS information for target' do
       expect_task('facts').always_return('os' => { 'name' => 'unix', 'family' => 'unix', 'release' => {} })
 
-      expect(run_plan('facts::info', 'nodes' => [node]).value).to eq(["#{node}: unix  (unix)"])
+      expect(run_plan('facts::info', 'targets' => [target]).value).to eq(["#{target}: unix  (unix)"])
     end
 
     it 'omits failed targets' do
-      expect_task('facts').always_return('_error' => { 'msg' => "Failed on #{node}" })
+      expect_task('facts').always_return('_error' => { 'msg' => "Failed on #{target}" })
 
-      expect(run_plan('facts::info', 'nodes' => [node]).value).to eq([])
+      expect(run_plan('facts::info', 'targets' => [target]).value).to eq([])
     end
   end
 
   context 'a winrm target' do
-    let(:node) { 'winrm://host' }
+    let(:target) { 'winrm://host' }
 
     it 'contains OS information for target' do
       expect_task('facts').always_return('os' => { 'name' => 'win', 'family' => 'win', 'release' => {} })
 
-      expect(run_plan('facts::info', 'nodes' => [node]).value).to eq(["#{node}: win  (win)"])
+      expect(run_plan('facts::info', 'targets' => [target]).value).to eq(["#{target}: win  (win)"])
     end
 
     it 'omits failed targets' do
-      expect_task('facts').always_return('_error' => { 'msg' => "Failed on #{node}" })
+      expect_task('facts').always_return('_error' => { 'msg' => "Failed on #{target}" })
 
-      expect(run_plan('facts::info', 'nodes' => [node]).value).to eq([])
+      expect(run_plan('facts::info', 'targets' => [target]).value).to eq([])
     end
   end
 
   context 'a pcp target' do
-    let(:node) { 'pcp://host' }
+    let(:target) { 'pcp://host' }
 
     it 'contains OS information for target' do
       expect_task('facts').always_return('os' => { 'name' => 'any', 'family' => 'any', 'release' => {} })
 
-      expect(run_plan('facts::info', 'nodes' => [node]).value).to eq(["#{node}: any  (any)"])
+      expect(run_plan('facts::info', 'targets' => [target]).value).to eq(["#{target}: any  (any)"])
     end
 
     it 'omits failed targets' do
-      expect_task('facts').always_return('_error' => { 'msg' => "Failed on #{node}" })
+      expect_task('facts').always_return('_error' => { 'msg' => "Failed on #{target}" })
 
-      expect(run_plan('facts::info', 'nodes' => [node]).value).to eq([])
+      expect(run_plan('facts::info', 'targets' => [target]).value).to eq([])
     end
   end
 
   context 'a local target' do
-    let(:node) { 'local://' }
+    let(:target) { 'local://' }
 
     it 'contains OS information for target' do
       expect_task('facts').always_return('os' => { 'name' => 'any', 'family' => 'any', 'release' => {} })
 
-      expect(run_plan('facts::info', 'nodes' => [node]).value).to eq(["#{node}: any  (any)"])
+      expect(run_plan('facts::info', 'targets' => [target]).value).to eq(["#{target}: any  (any)"])
     end
 
     it 'omits failed targets' do
-      expect_task('facts').always_return('_error' => { 'msg' => "Failed on #{node}" })
+      expect_task('facts').always_return('_error' => { 'msg' => "Failed on #{target}" })
 
-      expect(run_plan('facts::info', 'nodes' => [node]).value).to eq([])
+      expect(run_plan('facts::info', 'targets' => [target]).value).to eq([])
     end
   end
 
   context 'ssh, winrm, and pcp targets' do
-    let(:nodes) { %w[ssh://host1 winrm://host2 pcp://host3] }
+    let(:targets) { %w[ssh://host1 winrm://host2 pcp://host3] }
 
     it 'contains OS information for target' do
       expect_task('facts').return_for_targets(
-        nodes[0] => { 'os' => { 'name' => 'unix', 'family' => 'unix', 'release' => {} } },
-        nodes[1] => { 'os' => { 'name' => 'win', 'family' => 'win', 'release' => {} } },
-        nodes[2] => { 'os' => { 'name' => 'any', 'family' => 'any', 'release' => {} } }
+        targets[0] => { 'os' => { 'name' => 'unix', 'family' => 'unix', 'release' => {} } },
+        targets[1] => { 'os' => { 'name' => 'win', 'family' => 'win', 'release' => {} } },
+        targets[2] => { 'os' => { 'name' => 'any', 'family' => 'any', 'release' => {} } }
       )
 
-      expect(run_plan('facts::info', 'nodes' => nodes).value).to eq(
-        ["#{nodes[0]}: unix  (unix)", "#{nodes[1]}: win  (win)", "#{nodes[2]}: any  (any)"]
+      expect(run_plan('facts::info', 'targets' => targets).value).to eq(
+        ["#{targets[0]}: unix  (unix)", "#{targets[1]}: win  (win)", "#{targets[2]}: any  (any)"]
       )
     end
 
     it 'omits failed targets' do
-      target_results = nodes.each_with_object({}) do |node, h|
-        h[node] = { '_error' => { 'msg' => "Failed on #{node}" } }
+      target_results = targets.each_with_object({}) do |target, h|
+        h[target] = { '_error' => { 'msg' => "Failed on #{target}" } }
       end
       expect_task('facts').return_for_targets(target_results)
 
-      expect(run_plan('facts::info', 'nodes' => nodes).value).to eq([])
+      expect(run_plan('facts::info', 'targets' => targets).value).to eq([])
     end
   end
 end

--- a/spec/plans/init_spec.rb
+++ b/spec/plans/init_spec.rb
@@ -28,14 +28,14 @@ describe 'facts' do
       expect_task('facts').always_return(fact_output)
       inventory.expects(:add_facts).with(target, fact_output).returns(fact_output)
 
-      expect(run_plan('facts', 'nodes' => [node]).value).to eq(results(fact_output))
+      expect(run_plan('facts', 'targets' => [node]).value).to eq(results(fact_output))
     end
 
     it 'does not mask errors' do
       expect_task('facts').always_return(err_output)
       inventory.expects(:add_facts).never
 
-      expect(run_plan('facts', 'nodes' => [node]).value.msg).to eq("Plan aborted: run_task 'facts' failed on 1 target")
+      expect(run_plan('facts', 'targets' => [node]).value.msg).to eq("Plan aborted: run_task 'facts' failed on 1 target")
     end
   end
 
@@ -46,14 +46,14 @@ describe 'facts' do
       expect_task('facts').always_return(fact_output)
       inventory.expects(:add_facts).with(target, fact_output).returns(fact_output)
 
-      expect(run_plan('facts', 'nodes' => [node]).value).to eq(results(fact_output))
+      expect(run_plan('facts', 'targets' => [node]).value).to eq(results(fact_output))
     end
 
     it 'does not mask errors' do
       expect_task('facts').always_return(err_output)
       inventory.expects(:add_facts).never
 
-      expect(run_plan('facts', 'nodes' => [node]).value.msg).to eq("Plan aborted: run_task 'facts' failed on 1 target")
+      expect(run_plan('facts', 'targets' => [node]).value.msg).to eq("Plan aborted: run_task 'facts' failed on 1 target")
     end
   end
 
@@ -64,14 +64,14 @@ describe 'facts' do
       expect_task('facts').always_return(fact_output)
       inventory.expects(:add_facts).with(target, fact_output).returns(fact_output)
 
-      expect(run_plan('facts', 'nodes' => [node]).value).to eq(results(fact_output))
+      expect(run_plan('facts', 'targets' => [node]).value).to eq(results(fact_output))
     end
 
     it 'does not mask errors' do
       expect_task('facts').always_return(err_output)
       inventory.expects(:add_facts).never
 
-      expect(run_plan('facts', 'nodes' => [node]).value.msg).to eq("Plan aborted: run_task 'facts' failed on 1 target")
+      expect(run_plan('facts', 'targets' => [node]).value.msg).to eq("Plan aborted: run_task 'facts' failed on 1 target")
     end
   end
 
@@ -82,14 +82,14 @@ describe 'facts' do
       expect_task('facts').always_return(fact_output)
       inventory.expects(:add_facts).with(target, fact_output).returns(fact_output)
 
-      expect(run_plan('facts', 'nodes' => [node]).value).to eq(results(fact_output))
+      expect(run_plan('facts', 'targets' => [node]).value).to eq(results(fact_output))
     end
 
     it 'does not mask errors' do
       expect_task('facts').always_return(err_output)
       inventory.expects(:add_facts).never
 
-      expect(run_plan('facts', 'nodes' => [node]).value.msg).to eq("Plan aborted: run_task 'facts' failed on 1 target")
+      expect(run_plan('facts', 'targets' => [node]).value.msg).to eq("Plan aborted: run_task 'facts' failed on 1 target")
     end
   end
 
@@ -106,7 +106,7 @@ describe 'facts' do
       result_set = Bolt::ResultSet.new(
         nodes.map { |node| Bolt::Result.new(Bolt::Target.new(node), value: fact_output(node)) }
       )
-      expect(run_plan('facts', 'nodes' => nodes).value).to eq(result_set)
+      expect(run_plan('facts', 'targets' => nodes).value).to eq(result_set)
     end
 
     it 'does not mask errors' do
@@ -114,7 +114,7 @@ describe 'facts' do
       expect_task('facts').return_for_targets(target_results)
       inventory.expects(:add_facts).never
 
-      expect(run_plan('facts', 'nodes' => nodes).value.msg).to eq("Plan aborted: run_task 'facts' failed on 3 targets")
+      expect(run_plan('facts', 'targets' => nodes).value.msg).to eq("Plan aborted: run_task 'facts' failed on 3 targets")
     end
   end
 end


### PR DESCRIPTION
This changes the `$nodes` parameters in both the `facts` and
`facts::info` plans to `$targets` as part of a larger update to Bolt's
bundled content.

Part of https://github.com/puppetlabs/bolt/issues/1376