### PR TITLE
Source facts for systemd platforms using bash 3.1 and 3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.6.1
+### Fixed
+- Bash implementation now correctly detects platform information when using bash 3.1 and 3.2.
+
 ## 0.6.0
 ### Added
 - The `bash.sh` implementation can now provide distro code-name when possible.

--- a/tasks/bash.sh
+++ b/tasks/bash.sh
@@ -29,7 +29,8 @@ success() {
 # This is the preferred method and is checked first
 _systemd() {
   # These files may have unquoted spaces in the "pretty" fields even if the spec says otherwise
-  source <(sed 's/ /_/g' "$1")
+  # source cannot use process subsitution in some versions of bash, so redirect to stdin instead
+  source /dev/stdin <<<"$(sed 's/ /_/g' "$1")"
 
   # According to `man os-release`, the first entry in ID_LIKE
   # should be the one the platform most closely resembles


### PR DESCRIPTION
This fixes a bug where facts were not sourced correctly from
`/etc/os-release` or `/usr/lib/os-release` on systemd platforms when
using bash 3.1 or 3.2. Previously, the `os-release` file was sourced
by using process substitution, which is incompatible with some versions
of bash. This updates the script to source from `/dev/stdin` instead.