### PR TITLE
(maint) Update broken tests and add CODEOWNERS file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ cache: bundler
 before_install:
   - bundle -v
   - rm -f Gemfile.lock
-  - gem update --system $RUBYGEMS_VERSION
+  - "# Update system gems if requested. This is useful to temporarily workaround troubles in the test runner"
+  - "# See https://github.com/puppetlabs/pdk-templates/commit/705154d5c437796b821691b707156e1b056d244f for an example of how this was used"
+  - '[ -z "$RUBYGEMS_VERSION" ] || gem update --system $RUBYGEMS_VERSION'
   - gem --version
   - bundle -v
 script:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default to Bolt team
+* @puppetlabs/bolt

--- a/spec/plans/init_spec.rb
+++ b/spec/plans/init_spec.rb
@@ -35,7 +35,7 @@ describe 'facts' do
       expect_task('facts').always_return(err_output)
       inventory.expects(:add_facts).never
 
-      expect(run_plan('facts', 'nodes' => [node]).value.msg).to eq("Plan aborted: run_task 'facts' failed on 1 nodes")
+      expect(run_plan('facts', 'nodes' => [node]).value.msg).to eq("Plan aborted: run_task 'facts' failed on 1 target")
     end
   end
 
@@ -53,7 +53,7 @@ describe 'facts' do
       expect_task('facts').always_return(err_output)
       inventory.expects(:add_facts).never
 
-      expect(run_plan('facts', 'nodes' => [node]).value.msg).to eq("Plan aborted: run_task 'facts' failed on 1 nodes")
+      expect(run_plan('facts', 'nodes' => [node]).value.msg).to eq("Plan aborted: run_task 'facts' failed on 1 target")
     end
   end
 
@@ -71,7 +71,7 @@ describe 'facts' do
       expect_task('facts').always_return(err_output)
       inventory.expects(:add_facts).never
 
-      expect(run_plan('facts', 'nodes' => [node]).value.msg).to eq("Plan aborted: run_task 'facts' failed on 1 nodes")
+      expect(run_plan('facts', 'nodes' => [node]).value.msg).to eq("Plan aborted: run_task 'facts' failed on 1 target")
     end
   end
 
@@ -89,7 +89,7 @@ describe 'facts' do
       expect_task('facts').always_return(err_output)
       inventory.expects(:add_facts).never
 
-      expect(run_plan('facts', 'nodes' => [node]).value.msg).to eq("Plan aborted: run_task 'facts' failed on 1 nodes")
+      expect(run_plan('facts', 'nodes' => [node]).value.msg).to eq("Plan aborted: run_task 'facts' failed on 1 target")
     end
   end
 
@@ -114,7 +114,7 @@ describe 'facts' do
       expect_task('facts').return_for_targets(target_results)
       inventory.expects(:add_facts).never
 
-      expect(run_plan('facts', 'nodes' => nodes).value.msg).to eq("Plan aborted: run_task 'facts' failed on 3 nodes")
+      expect(run_plan('facts', 'nodes' => nodes).value.msg).to eq("Plan aborted: run_task 'facts' failed on 3 targets")
     end
   end
 end


### PR DESCRIPTION
This addresses an issue with Travis and bundler that causes
rubygems-update to fail.

It also updates expected output in tests to account for Bolt outputting
`target` instead of `node`.

Lastly, this adds the bolt team as codeowners.