### PR TITLE
(GH-34) Return version when using `uname`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.6.1
 ### Fixed
 - Bash implementation now correctly detects platform information when using bash 3.1 and 3.2.
+- Bash implementation now correctly returns the platform version when using `uname` to determine the platform name and version.
 
 ## 0.6.0
 ### Added

--- a/tasks/bash.sh
+++ b/tasks/bash.sh
@@ -73,7 +73,7 @@ _rhel() {
 # Last resort
 _uname() {
   [[ $ID ]] || ID="$(uname)"
-  [[ $full ]] || full="$(uname -r)"
+  [[ $VERSION_ID ]] || VERSION_ID="$(uname -r)"
 }
 
 # Taken from https://github.com/puppetlabs/facter/blob/master/lib/inc/facter/facts/os.hpp


### PR DESCRIPTION
This updates the `facts` task to properly return a platform's version
when it falls back to using `uname` to determine the platform name and
version. Previously, whenever the task fell back to using `uname`, it
would return an empty string for the version.

Fixes #34 