### PR TITLE
Delegate to facter if installed

### DIFF
--- a/tasks/bash.sh
+++ b/tasks/bash.sh
@@ -28,8 +28,10 @@ success() {
 maybe_delegate_to_facter() {
   export PATH=$PATH:/opt/puppetlabs/bin
 
-  # Only use facter if we're not looking up a specific fact (from the puppet-agent task)
-  if [ "x$1" == "x" ] && command -v facter > /dev/null 2>&1; then
+  # Only use facter if we're running as the "facts" task, not the "facts::bash"
+  # task. This also skips calling facter if we're running as a script, which is
+  # used by the puppet_agent task.
+  if [ "x$PT__task" == "xfacts" ] && command -v facter > /dev/null 2>&1; then
     # Include the --show-legacy flag for Facter 3+
     facter_version="$(facter -v)"
     version_regex='^[0-2]'

--- a/tasks/powershell.ps1
+++ b/tasks/powershell.ps1
@@ -17,6 +17,13 @@ function ErroMessage {
 # Server Core.
 if ([System.Environment]::OSVersion.Platform -gt 2) {
     ErroMessage
+} elseif (Get-Command facter -ErrorAction SilentlyContinue) {
+  $version = facter -v | Out-String
+  if ($version -match '^[0-2]') {
+    facter -p --json
+  } else {
+    facter -p --json --show-legacy
+  }
 } else {
     $release = [System.Environment]::OSVersion.Version.ToString() -replace '\.[^.]*\z'
     $version = $release -replace '\.[^.]*\z'

--- a/tasks/powershell.ps1
+++ b/tasks/powershell.ps1
@@ -17,7 +17,7 @@ function ErroMessage {
 # Server Core.
 if ([System.Environment]::OSVersion.Platform -gt 2) {
     ErroMessage
-} elseif (Get-Command facter -ErrorAction SilentlyContinue) {
+} elseif ($env:PT__task -eq 'facts' -and (Get-Command facter -ErrorAction SilentlyContinue)) {
   $version = facter -v | Out-String
   if ($version -match '^[0-2]') {
     facter -p --json


### PR DESCRIPTION
This restores the behavior that was removed in 9b7fe39, whereby the
shell and powershell implementations of the facts task will detect
whether `facter` is available and call out to it if possible.

This was removed because it leads to a situation where you can get
different kinds of output from the same implementation of the task
depending on where it's being run. But since the unit of abstraction is
the task itself, and not an implementation, it's better to provide the
full `facter` output in as many cases as possible, without the user
having to explicitly mark the target as having the `puppet-agent`
feature first. This makes the output less consistent between targets for
the same implementation, but more consistent for the same target between
implementations.