### PR TITLE
(bug-fix) Use RbConfig.ruby instead of hardcoded path

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,3 +1,5 @@
 fixtures:
+  forge_modules:
+    ruby_task_helper: 'puppetlabs/ruby_task_helper'
   symlinks:
     facts: "#{source_dir}"

--- a/tasks/init.json
+++ b/tasks/init.json
@@ -1,7 +1,8 @@
 {
   "description": "Gather system facts",
   "parameters": {},
-  "input_method": "environment",
+  "input_method": "both",
+  "files": ["ruby_task_helper/files/task_helper.rb"],
   "implementations": [
     {"name": "ruby.rb", "requirements": ["puppet-agent"]},
     {"name": "powershell.ps1", "requirements": ["powershell"]},


### PR DESCRIPTION
We rely on the puppet-agent being installed for targets that have the
`pupet-agent` feature. However we assign `puppet-agent` to localhost
expecting it will use Bolt's puppet-agent, which means puppet resources
aren't at the expected `/opt/puppetlabs/puppet` path. This will now look
for facter packaged with Puppet first, then packaged with
Bolt, then lastly will just call `facter` to see if it's elsewhere on
the PATH.

This also makes a number of modifications to how the executable string
is munged and called on Windows, so that the task is runnable on that
platform. It also uses the ruby_task_helper module in order to catch and
display errors.