### PR TITLE
(GH-42) Format plan metadata for plan parameters

### DIFF
--- a/plans/info.pp
+++ b/plans/info.pp
@@ -1,10 +1,11 @@
-# A plan that prints basic OS information for the specified targets. It first
-# runs the facts task to retrieve facts from the targets, then compiles the
-# desired OS information from the os fact value of each targets.
+# @summary
+#   A plan that prints basic OS information for the specified targets. It first
+#   runs the facts task to retrieve facts from the targets, then compiles the
+#   desired OS information from the os fact value of each targets. This plan primarily
+#   provides readable formatting, and ignores targets that error.
 #
-# The $targets parameter is a list of the targets for which to print the OS
-# information. This plan primarily provides readable formatting, and ignores
-# targets that error.
+# @param targets List of the targets for which to print the OS information.
+# @return List of strings formatted as "$target_name: $os"
 plan facts::info(TargetSpec $targets) {
   return run_task('facts', $targets, '_catch_errors' => true).reduce([]) |$info, $r| {
     if ($r.ok) {

--- a/plans/init.pp
+++ b/plans/init.pp
@@ -1,7 +1,9 @@
-# A plan that retrieves facts and stores in the inventory for the
-# specified targets.
+# @summary
+#  A plan that retrieves facts and stores in the inventory for the
+#  specified targets.
 #
-# The $targets parameter is a list of targets to retrieve the facts for.
+# @param targets List of targets to retrieve the facts for.
+# @return ResultSet of Task results.
 plan facts(TargetSpec $targets) {
   $result_set = run_task('facts', $targets)
 


### PR DESCRIPTION
This commit updates the puppet-strings docs for plan parameters so that CLI and console can print metadata.