### PR TITLE
(IAC-1127) search for facter.exe on Windows platforms

### DIFF
--- a/tasks/ruby.rb
+++ b/tasks/ruby.rb
@@ -5,15 +5,22 @@ require_relative "../../ruby_task_helper/files/task_helper.rb"
 
 class Facts < TaskHelper
   def facter_executable
-    install_path = File.join(File.dirname(RbConfig.ruby), 'facter')
+    exe_path = File.join(File.dirname(RbConfig.ruby), 'facter.exe')
+    bat_path = File.join(File.dirname(RbConfig.ruby), 'facter.bat')
+    ruby_path = File.join(File.dirname(RbConfig.ruby), 'facter')
 
-    # Fall back to PATH lookup if puppet-agent isn't installed
-    if File.exist?(install_path)
-      # Paths with spaces must be quoted on Windows, which means slashes need escaping
-      Gem.win_platform? ? "\"#{install_path}\"" : install_path
-    else
-      'facter'
+    if Gem.win_platform?
+      if File.exist?(exe_path)
+        return "\"#{exe_path}\""
+      elsif File.exist?(bat_path)
+        return "\"#{bat_path}\""
+      end
+    elsif File.exist?(ruby_path)
+      return ruby_path
     end
+
+    # Fall back to PATH lookup if known path does not exist
+    'facter'
   end
 
   def task(opts = {})


### PR DESCRIPTION
Before this change, the facts task would assume that if #{rubydir}/facter exists, this should be the executable for facter.
On Puppet Agent 6 this file exists and is the entry point for linux. The entry point for windows on Puppet 6 that ships with cFacter is  #{rubydir}/facter.exe .
Open 3 knows how to execute files on Windows without explicitly specifying the extensions, eg:
```
irb(main):006:0> stdout, stderr, status = Open3.capture3("C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin\\ruby.exe", "-v")

irb(main):007:0> stdout, stderr, status = Open3.capture3("C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin\\ruby", "-v")
```
On Puppet Agent 7, we ship Facter 4 that is written in ruby, so facter.exe executable no longer exists. Because of this:
_C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin\\facter_ exists as the Ruby entrypoint for facter, but C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin\\facter.exe no longer exists causing the facts task to fail on Windows.

The changes from this PR should work on Puppet Agent 6 (with cFacter) and Puppet Agent 7 (with Ruby Facter)