### PR TITLE
Bubble up errors from facter if any

### DIFF
--- a/tasks/ruby.rb
+++ b/tasks/ruby.rb
@@ -21,10 +21,20 @@ class Facts < TaskHelper
     stdout, stderr, status = Open3.capture3("#{facter_executable} -v")
 
     if stdout =~ /^[0-2]\./
-      exec("#{facter_executable} -p --json")
+      facter_args = "-p --json"
     else
-      exec("#{facter_executable} -p --json --show-legacy")
+      facter_args = "-p --json --show-legacy"
     end
+
+    stdout, stderr, status = Open3.capture3("#{facter_executable} #{facter_args}")
+
+    result = JSON.parse(stdout)
+
+    if status.exitstatus != 0
+      result[:_error] = { msg: stderr }
+    end
+
+    return result
   end
 end
 


### PR DESCRIPTION
Prior to this commit, when facter would throw up errors we
would just eat them and not give any context as to why
facter gave an exit code of 1.

After this commit, we surface errors from facter in the
task result.