### PR TITLE
Use bat files if possible

### DIFF
--- a/tasks/ruby.rb
+++ b/tasks/ruby.rb
@@ -38,10 +38,10 @@ class Facts < TaskHelper
     ruby_path = File.join(File.dirname(RbConfig.ruby), type)
 
     if Gem.win_platform?
-      if File.exist?(exe_path)
-        return "\"#{exe_path}\""
-      elsif File.exist?(bat_path)
+      if File.exist?(bat_path)
         return "\"#{bat_path}\""
+      elsif File.exist?(exe_path)
+        return "\"#{exe_path}\""
       end
     elsif File.exist?(ruby_path)
       return ruby_path


### PR DESCRIPTION
This fixes issue: https://github.com/puppetlabs/bolt/issues/2344

The puppetlabs-facts module should use the bat files preferably as the environment setup that is done in the bat file is needed for facter to avoid the ruby errors. 

Testing run with this fix available here: https://github.com/puppetlabs/puppetlabs-iis/actions/runs/383224064