### PR TITLE
(maint) Clean up task metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 1.3.0
+### Changed
+- Look for and prefer `.bat` executables for windows platforms in the ruby implementation.
+- Update task metadata to explicitly define file requirements and input_method.
+
 ## 1.2.0
 ### Changed
 - Replace `facter -p` with `puppet facts show` for Puppet 7.

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-facts",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "author": "puppet",
   "summary": "Tasks that inspect the value of system facts",
   "license": "Apache-2.0",

--- a/tasks/init.json
+++ b/tasks/init.json
@@ -1,11 +1,22 @@
 {
   "description": "Gather system facts",
   "parameters": {},
-  "input_method": "both",
-  "files": ["ruby_task_helper/files/task_helper.rb"],
   "implementations": [
-    {"name": "ruby.rb", "requirements": ["puppet-agent"]},
-    {"name": "powershell.ps1", "requirements": ["powershell"]},
-    {"name": "bash.sh", "requirements": ["shell"]}
+    { 
+      "name": "ruby.rb",
+      "requirements": ["puppet-agent"],
+      "files": ["ruby_task_helper/files/task_helper.rb"],
+      "input_method": "stdin"
+    },
+    {
+      "name": "powershell.ps1",
+      "requirements": ["powershell"],
+      "input_method": "environment"
+    },
+    { 
+      "name": "bash.sh",
+      "requirements": ["shell"],
+      "input_method": "environment"
+    }
   ]
 }

--- a/tasks/powershell.json
+++ b/tasks/powershell.json
@@ -1,5 +1,6 @@
 {
   "description": "Gather system facts using powershell",
   "private": true,
+  "input_method": "environment",
   "parameters": {}
 }

--- a/tasks/ruby.json
+++ b/tasks/ruby.json
@@ -1,5 +1,7 @@
 {
   "description": "Gather system facts using ruby and facter",
+  "files": ["ruby_task_helper/files/task_helper.rb"],
   "private": true,
+  "input_method": "stdin",
   "parameters": {}
 }


### PR DESCRIPTION
Explicitly require the task helper for the task that uses it and do not explicitly use `both` as the input method as it is the default.