### PR TITLE
(maint) Prep for 1.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.5.0
+### Changed
+- The `os` fact now correctly capitalizes freebsd to FreeBSD for the fact ID and `family` keys.
+
 ## 1.4.0
 ### Changed
 - Bump maximum Puppet version to include 7.x

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-facts",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "author": "puppet",
   "summary": "Tasks that inspect the value of system facts",
   "license": "Apache-2.0",


### PR DESCRIPTION
Release the updated OS fact with correct casing for FreeBSD.