### PR TITLE
sh tasks: Run with set -e

### DIFF
--- a/tasks/bash.sh
+++ b/tasks/bash.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # This script may be called outside of a task, e.g. by puppet_agent
 # so we have to just paste this code here.  *grumbles*
 # Exit with an error message and error code, defaulting to 1


### PR DESCRIPTION
This ensures that the task doesn't continue when an error happened. This is also best practice in bash. We noticed an error at https://github.com/puppetlabs/puppetlabs-postgresql/actions/runs/8630671386/job/23657771763?pr=1488